### PR TITLE
Resolve `pip install .` error with data and logs folders.

### DIFF
--- a/Colony_mask_training_inference/pyproject.toml
+++ b/Colony_mask_training_inference/pyproject.toml
@@ -24,3 +24,7 @@ license = {text = "AISL"}
 
 [tool.pdm]
 distribution = false
+
+[build-system]
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"


### PR DESCRIPTION
Fixes #25. See the issue for background.

# Changes
Use the pdm backend always, instead of letting pip choose setuptools.

# Testing
```bash
$ cd Colony_mask_training_inference
$ ls
ColonyMask_merging_thresholding_rearranging.py            eval.log        README.md
configs                                                   logs            test-tifffile
data                                                      pdm.lock        train.log
EMT_ColonyMask_merging_thresholding_rearranging.egg-info  pyproject.toml
$ python -m venv venv
$ source venv/bin/activate
$ pip install .
```
(Note the presence of the `logs` and `data` directories at the `ls` step.)